### PR TITLE
Add tests for Fenwick Tree (#12)

### DIFF
--- a/tests/test_fenwicktree.py
+++ b/tests/test_fenwicktree.py
@@ -84,18 +84,53 @@ class TestFenwickTree:
         fenwicktree.add(0, -5)
         assert fenwicktree.data == [-4, -2, 3, 5, 5]
 
-    def test_add_when_floating_point_value_is_given(self, fenwicktree):
+    def test_add_when_zero_is_given(self, fenwicktree):
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
 
         GIVEN an initialized fenwicktree object
-        WHEN add floating point value at arbitrary positions in the sequence
+        WHEN add zero at arbitrary positions in the sequence
+        THEN fenwicktree.data has a partial sum at any position in the sequence
+        '''
+
+        for i in range(5):
+            fenwicktree.add(i, i + 1)
+
+        assert fenwicktree.data == [1, 3, 3, 10, 5]
+
+        fenwicktree.add(0, 0)
+        assert fenwicktree.data == [1, 3, 3, 10, 5]
+
+    def test_add_when_positive_floating_point_value_is_given(self,
+                                                             fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add positive floating point value at arbitrary positions in the
+             sequence
         THEN fenwicktree.data has a partial sum at any position in the sequence
         '''
 
         fenwicktree.add(0, 1.5)
         assert fenwicktree.data == [1.5, 1.5, 0, 1.5, 0]
+
+    def test_add_when_negative_floating_point_value_is_given(self,
+                                                             fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add negative floating point value at arbitrary positions in the
+             sequence
+        THEN fenwicktree.data has a partial sum at any position in the sequence
+        '''
+
+        fenwicktree.add(0, -1.5)
+        assert fenwicktree.data == [-1.5, -1.5, 0, -1.5, 0]
 
     @pytest.mark.parametrize((
         'left', 'right', 'expected'

--- a/tests/test_fenwicktree.py
+++ b/tests/test_fenwicktree.py
@@ -1,0 +1,203 @@
+import pytest
+
+from atcoder.fenwicktree import FenwickTree
+
+
+@pytest.fixture
+def fenwicktree():
+    return FenwickTree(5)
+
+
+class TestFenwickTree:
+
+    def test_initial_status(self, fenwicktree):
+        '''
+        An initialized fenwicktree object is expected to have all the elements
+        0.
+
+        GIVEN an initialized fenwicktree object
+        WHEN before executing fenwicktree.add(p, x)
+        THEN all the elements are 0
+        '''
+
+        assert fenwicktree.data == [0, 0, 0, 0, 0]
+
+        pair_of_positions = self._generate_pair_of_positions()
+
+        for left, right in pair_of_positions:
+            assert fenwicktree.sum(left, right) == 0
+
+    def _generate_pair_of_positions(self):
+        from itertools import combinations_with_replacement
+
+        return list(combinations_with_replacement(range(5), 2))
+
+    def test_add(self, fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add 1 to the first in the number sequence
+        THEN fenwicktree.data has [1, 1, 0, 1, 0]
+        '''
+
+        fenwicktree.add(0, 1)
+        assert fenwicktree.data == [1, 1, 0, 1, 0]
+
+    def test_add_multiple_times(self, fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add arbitrary value(s) at arbitrary positions in the sequence
+        THEN fenwicktree.data has a partial sum at any position in the sequence
+        '''
+
+        expected = [[1, 1, 0, 1, 0],
+                    [1, 3, 0, 3, 0],
+                    [1, 3, 3, 6, 0],
+                    [1, 3, 3, 10, 0],
+                    [1, 3, 3, 10, 5]
+                    ]
+
+        for i in range(5):
+            fenwicktree.add(i, i + 1)
+            assert fenwicktree.data == expected[i]
+
+    def test_add_when_negative_value_is_given(self, fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add negative value at arbitrary positions in the sequence
+        THEN fenwicktree.data has a partial sum at any position in the sequence
+        '''
+
+        for i in range(5):
+            fenwicktree.add(i, i + 1)
+
+        assert fenwicktree.data == [1, 3, 3, 10, 5]
+
+        fenwicktree.add(0, -5)
+        assert fenwicktree.data == [-4, -2, 3, 5, 5]
+
+    def test_add_when_floating_point_value_is_given(self, fenwicktree):
+        '''
+        fenwicktree.add(p, x) is expected to add x to the p-th of the number
+        sequence.
+
+        GIVEN an initialized fenwicktree object
+        WHEN add floating point value at arbitrary positions in the sequence
+        THEN fenwicktree.data has a partial sum at any position in the sequence
+        '''
+
+        fenwicktree.add(0, 1.5)
+        assert fenwicktree.data == [1.5, 1.5, 0, 1.5, 0]
+
+    @pytest.mark.parametrize((
+        'left', 'right', 'expected'
+    ), [
+        (0, 5, 15),
+        (0, 4, 10),
+        (1, 4, 9),
+        (1, 3, 5),
+        (2, 2, 0),
+    ])
+    def test_sum(self, fenwicktree, left, right, expected):
+        '''
+        fenwicktree.sum(left, right) is expected to calculate the sum of the
+        interval [left, right)
+
+        GIVEN With arbitrary value(s) at arbitrary positions in the sequence
+              added to an initialized fenwicktree object
+        WHEN specify the interval [left, right)
+        THEN returns the sum of interval [left, right)
+        '''
+
+        for i in range(5):
+            fenwicktree.add(i, i + 1)
+
+        assert fenwicktree.sum(left, right) == expected
+
+    @pytest.mark.parametrize((
+        'left', 'right', 'expected'
+    ), [
+        (0, 5, 17),
+        (0, 4, 12),
+        (0, 3, 8),
+        (0, 2, 3),
+        (0, 1, 1),
+        (1, 4, 11),
+        (1, 3, 7),
+        (2, 2, 0),
+    ])
+    def test_sum_when_additional_element_is_given(self, fenwicktree,
+                                                  left, right, expected):
+        '''
+        fenwicktree.sum(left, right) is expected to calculate the sum of the
+        interval [left, right)
+
+        GIVEN With arbitrary value(s) at arbitrary positions in the sequence
+              added to an initialized fenwicktree object
+        WHEN specify the interval [left, right) after the additional element
+             is given
+        THEN returns the sum of interval [left, right)
+        '''
+
+        for i in range(5):
+            fenwicktree.add(i, i + 1)
+
+        assert fenwicktree.sum(0, 5) == 15
+
+        fenwicktree.add(2, 2)
+        assert fenwicktree.data == [1, 3, 5, 12, 5]
+        assert fenwicktree.sum(left, right) == expected
+
+    @pytest.mark.parametrize((
+        'p'
+    ), [
+        -2,
+        -1,
+        5,
+        6,
+    ])
+    def test_add_failed_if_invalid_input_is_given(self, fenwicktree, p):
+        '''
+        fenwicktree.add(p, x) is expected to be raised an AssertionError if an
+        invalid input is given.
+
+        GIVEN an initialized fenwicktree object
+        WHEN an out-of-range index is given
+        THEN raises an AssertionError
+        '''
+
+        with pytest.raises(AssertionError):
+            fenwicktree.add(p, None)
+
+    @pytest.mark.parametrize((
+        'left', 'right'
+    ), [
+        (-2, 5),
+        (-1, 5),
+        (0, 6),
+        (0, 7),
+        (3, 2),
+        (-1, 6),
+        (-1, 7),
+    ])
+    def test_sum_failed_if_invalid_input_is_given(self, fenwicktree,
+                                                  left, right):
+        '''
+        fenwicktree.sum(left, right) is expected to be raised an AssertionError
+        if an invalid input is given.
+
+        GIVEN an initialized fenwicktree object
+        WHEN an out-of-range index is given
+        THEN raises an AssertionError
+        '''
+
+        with pytest.raises(AssertionError):
+            fenwicktree.sum(left, right)

--- a/tests/test_fenwicktree.py
+++ b/tests/test_fenwicktree.py
@@ -1,16 +1,17 @@
 import pytest
+from typing import List, Tuple
 
 from atcoder.fenwicktree import FenwickTree
 
 
 @pytest.fixture
-def fenwicktree():
+def fenwicktree() -> FenwickTree:
     return FenwickTree(5)
 
 
 class TestFenwickTree:
 
-    def test_initial_status(self, fenwicktree):
+    def test_initial_status(self, fenwicktree: FenwickTree) -> None:
         '''
         An initialized fenwicktree object is expected to have all the elements
         0.
@@ -27,12 +28,12 @@ class TestFenwickTree:
         for left, right in pair_of_positions:
             assert fenwicktree.sum(left, right) == 0
 
-    def _generate_pair_of_positions(self):
+    def _generate_pair_of_positions(self) -> List[Tuple[int, ...]]:
         from itertools import combinations_with_replacement
 
         return list(combinations_with_replacement(range(5), 2))
 
-    def test_add(self, fenwicktree):
+    def test_add(self, fenwicktree: FenwickTree) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -45,7 +46,7 @@ class TestFenwickTree:
         fenwicktree.add(0, 1)
         assert fenwicktree.data == [1, 1, 0, 1, 0]
 
-    def test_add_multiple_times(self, fenwicktree):
+    def test_add_multiple_times(self, fenwicktree: FenwickTree) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -66,7 +67,9 @@ class TestFenwickTree:
             fenwicktree.add(i, i + 1)
             assert fenwicktree.data == expected[i]
 
-    def test_add_when_negative_value_is_given(self, fenwicktree):
+    def test_add_when_negative_value_is_given(
+        self, fenwicktree: FenwickTree
+    ) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -84,7 +87,7 @@ class TestFenwickTree:
         fenwicktree.add(0, -5)
         assert fenwicktree.data == [-4, -2, 3, 5, 5]
 
-    def test_add_when_zero_is_given(self, fenwicktree):
+    def test_add_when_zero_is_given(self, fenwicktree: FenwickTree) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -102,8 +105,9 @@ class TestFenwickTree:
         fenwicktree.add(0, 0)
         assert fenwicktree.data == [1, 3, 3, 10, 5]
 
-    def test_add_when_positive_floating_point_value_is_given(self,
-                                                             fenwicktree):
+    def test_add_when_positive_floating_point_value_is_given(
+        self, fenwicktree: FenwickTree
+    ) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -117,8 +121,9 @@ class TestFenwickTree:
         fenwicktree.add(0, 1.5)
         assert fenwicktree.data == [1.5, 1.5, 0, 1.5, 0]
 
-    def test_add_when_negative_floating_point_value_is_given(self,
-                                                             fenwicktree):
+    def test_add_when_negative_floating_point_value_is_given(
+        self, fenwicktree: FenwickTree
+    ) -> None:
         '''
         fenwicktree.add(p, x) is expected to add x to the p-th of the number
         sequence.
@@ -141,7 +146,9 @@ class TestFenwickTree:
         (1, 3, 5),
         (2, 2, 0),
     ])
-    def test_sum(self, fenwicktree, left, right, expected):
+    def test_sum(
+        self, fenwicktree: FenwickTree, left: int, right: int, expected: int
+    ) -> None:
         '''
         fenwicktree.sum(left, right) is expected to calculate the sum of the
         interval [left, right)
@@ -169,8 +176,9 @@ class TestFenwickTree:
         (1, 3, 7),
         (2, 2, 0),
     ])
-    def test_sum_when_additional_element_is_given(self, fenwicktree,
-                                                  left, right, expected):
+    def test_sum_when_additional_element_is_given(
+        self, fenwicktree: FenwickTree, left: int, right: int, expected: int
+    ) -> None:
         '''
         fenwicktree.sum(left, right) is expected to calculate the sum of the
         interval [left, right)
@@ -199,7 +207,9 @@ class TestFenwickTree:
         5,
         6,
     ])
-    def test_add_failed_if_invalid_input_is_given(self, fenwicktree, p):
+    def test_add_failed_if_invalid_input_is_given(
+        self, fenwicktree: FenwickTree, p: int
+    ) -> None:
         '''
         fenwicktree.add(p, x) is expected to be raised an AssertionError if an
         invalid input is given.
@@ -223,8 +233,9 @@ class TestFenwickTree:
         (-1, 6),
         (-1, 7),
     ])
-    def test_sum_failed_if_invalid_input_is_given(self, fenwicktree,
-                                                  left, right):
+    def test_sum_failed_if_invalid_input_is_given(
+        self, fenwicktree: FenwickTree, left: int, right: int
+    ) -> None:
         '''
         fenwicktree.sum(left, right) is expected to be raised an AssertionError
         if an invalid input is given.


### PR DESCRIPTION
## WHAT

+ FenwickTreeに関するテストを追加しました。各メソッドの挙動について、テストしている項目を列挙します。

### addメソッドを実行する前の初期状態に関するテスト

該当メソッド: `test_initial_status()`

+ データを保持するリストの値は、全て0
+ 任意の区間を指定したときの和は、いずれも0

### addメソッドを実行したときのテスト

該当メソッド: `test_add_xxxx()`
xxxxは、テストのバリエーションを表す

+ addメソッドを1回実行
  + 任意の位置pに対して、正の整数を追加
  + 任意の位置pに対して、正の小数を追加
  + 任意の位置pに対して、負の小数を追加
+ addメソッドを複数回実行
  + 任意の位置pに対して、正の整数を追加
  + 正の整数を複数回追加した後で、任意の位置pに対して0を追加（操作の前後で、結果が変わらないことを示すため）
  + 正の整数を複数回追加した後で、任意の位置pに対して負の整数を追加

### sumメソッドを実行したときのテスト

該当メソッド: `test_sum_xxxx()`
xxxxは、テストのバリエーションを表す

+ addメソッドを複数回実行した後で、sumメソッドを1回実行
+ 上記のパターンに加え、追加でaddメソッドを実行してから、sumメソッドを実行

### 範囲外のindexを指定したときのテスト

該当メソッド: `test_xxxx_failed_if_invalid_input_is_given()`
xxxxは、テストするメソッド名を表す

+ `add`に関しては、要素の位置pについて範囲外（下限もしくは上限を超える場合）のindexを与えました

+ `sum`に関しては、左右の区間について範囲外のindexを与えました
  + 片方のみ範囲外（下限もしくは上限を超える場合）となるindexを指定
  + 両方が範囲外となるindexを指定
  + 左側のindexが右側のindexよりも大きくなる場合

## Questions

+ protectedメソッドである_sum()メソッドのテストについて、どのようにお考えでしょうか?
  + publicメソッドと同様にテストする必要がある
  + sum()メソッドで間接的にテストしているため不要