### PR TITLE
DSU with path halving

### DIFF
--- a/atcoder/dsu.py
+++ b/atcoder/dsu.py
@@ -3,13 +3,14 @@ import typing
 
 class DSU:
     '''
-    Implement (union by size) + (path compression)
+    Implement (union by size) + (path halving)
+
     Reference:
     Zvi Galil and Giuseppe F. Italiano,
     Data structures and algorithms for disjoint set union problems
     '''
 
-    def __init__(self, n: int = 0):
+    def __init__(self, n: int = 0) -> None:
         self._n = n
         self.parent_or_size = [-1] * n
 
@@ -40,11 +41,17 @@ class DSU:
     def leader(self, a: int) -> int:
         assert 0 <= a < self._n
 
-        if self.parent_or_size[a] < 0:
-            return a
+        parent = self.parent_or_size[a]
+        while parent >= 0:
+            if self.parent_or_size[parent] < 0:
+                return parent
+            self.parent_or_size[a], a, parent = (
+                self.parent_or_size[parent],
+                self.parent_or_size[parent],
+                self.parent_or_size[self.parent_or_size[parent]]
+            )
 
-        self.parent_or_size[a] = self.leader(self.parent_or_size[a])
-        return self.parent_or_size[a]
+        return a
 
     def size(self, a: int) -> int:
         assert 0 <= a < self._n

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,9 @@ lint =
     flake8
     pep8-naming
     mypy
-test = pytest
+test =
+    pytest
+    pytest-benchmark
 docs =
     sphinx
     sphinx_rtd_theme

--- a/tests/test_dsu.py
+++ b/tests/test_dsu.py
@@ -1,22 +1,19 @@
 from itertools import combinations
 import pytest
+import random
 from typing import List, Tuple
+
+from pytest_benchmark.fixture import BenchmarkFixture
 
 from atcoder.dsu import DSU
 
 
 class TestDsu:
 
-    def _dsu(self, n: int = 5) -> DSU:
-        return DSU(n)
-
-    def _get_all_pairs(self, n: int = 5) -> List[Tuple[int, ...]]:
-        return list(combinations(range(n), 2))
-
     def test_initial_status(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
-        for i, j in self._get_all_pairs():
+        for i, j in combinations(range(5), 2):
             assert not dsu.same(i, j)
 
         for index in range(5):
@@ -26,7 +23,7 @@ class TestDsu:
         assert dsu.groups() == [[0], [1], [2], [3], [4]]
 
     def test_merge(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
         assert not dsu.same(0, 1)
 
@@ -41,7 +38,7 @@ class TestDsu:
                         dsu.merge(i, j)
 
     def test_merge_elements_of_same_group(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
         assert not dsu.same(0, 1)
 
@@ -57,7 +54,7 @@ class TestDsu:
                         dsu.same(i, j)
 
     def test_size(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
         dsu.merge(0, 1)
         assert dsu.size(0) == 2
@@ -70,7 +67,7 @@ class TestDsu:
                 dsu.size(i)
 
     def test_leader(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
         dsu.merge(0, 1)
         dsu.merge(0, 2)
@@ -87,9 +84,24 @@ class TestDsu:
                 dsu.leader(i)
 
     def test_groups(self) -> None:
-        dsu = self._dsu()
+        dsu = DSU(5)
 
         dsu.merge(0, 1)
         dsu.merge(0, 2)
 
         assert dsu.groups() == [[0, 1, 2], [3], [4]]
+
+    def _merge_benchmark(self, dsu: DSU, pairs: List[Tuple[int, int]]) -> None:
+        for i, j in pairs:
+            dsu.merge(i, j)
+
+    def test_benchmark(self, benchmark: BenchmarkFixture) -> None:
+        random.seed(0)
+        n = 100000
+
+        dsu = DSU(n)
+        pairs = []
+        for _ in range(1000000):
+            pairs.append((random.randrange(0, n), random.randrange(0, n)))
+
+        benchmark(self._merge_benchmark, dsu, pairs)


### PR DESCRIPTION
resolve #28.

This PR introduces no-recursive DSU using path halving. I compared path compression, path splitting, and path halving. Runtimes of path splitting and path halving are shorter than the master's one, and they are almost the same. I selected path halving because of the simplicity of implementation.

### Benchmark result (1,000,000 times merging)
```
--------------------------------------------------------------------------------------------- benchmark: 4 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                        Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark (0004_halving)       684.8580 (1.0)        712.0260 (1.00)       696.0139 (1.0)      12.2154 (2.68)       692.3994 (1.0)      21.8737 (3.08)          1;0  1.4368 (1.0)           5           1
test_benchmark (0003_splitti)       697.6434 (1.02)       708.4840 (1.0)        702.0563 (1.01)      4.5543 (1.0)        702.9542 (1.02)      7.1003 (1.0)           1;0  1.4244 (0.99)          5           1
test_benchmark (0001_master)      1,145.4572 (1.67)     1,182.5952 (1.67)     1,165.7987 (1.67)     18.0817 (3.97)     1,170.4463 (1.69)     35.0408 (4.94)          1;0  0.8578 (0.60)          5           1
test_benchmark (0002_compres)     1,149.8620 (1.68)     1,264.3050 (1.78)     1,193.5093 (1.71)     43.6715 (9.59)     1,180.0830 (1.70)     50.7904 (7.15)          1;0  0.8379 (0.58)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

### Result of AtCoder Library Practice Contest
- master (440 ms) https://atcoder.jp/contests/practice2/submissions/18704102
- path compression (455 ms) https://atcoder.jp/contests/practice2/submissions/18704105
- path splitting (403 ms) https://atcoder.jp/contests/practice2/submissions/18704114
- path halving (394 ms) https://atcoder.jp/contests/practice2/submissions/18704122

### Implementations
```
# master
def leader(self, a: int) -> int:
    assert 0 <= a < self._n

    if self.parent_or_size[a] < 0:
        return a

    self.parent_or_size[a] = self.leader(self.parent_or_size[a])
    return self.parent_or_size[a]

# path compression
def leader(self, a: int) -> int:
    assert 0 <= a < self._n

    leader = a
    while self.parent_or_size[leader] >= 0:
        leader = self.parent_or_size[leader]

    while self.parent_or_size[a] >= 0:
        self.parent_or_size[a], a = leader, self.parent_or_size[a]

    return leader

# path splitting
def leader(self, a: int) -> int:
    assert 0 <= a < self._n

    parent = self.parent_or_size[a]
    if parent < 0:
        return a

    while self.parent_or_size[parent] >= 0:
        self.parent_or_size[a], a, parent = (
            self.parent_or_size[parent],
            parent,
            self.parent_or_size[parent],
        )

    return parent

# path halving
def leader(self, a: int) -> int:
    assert 0 <= a < self._n

    parent = self.parent_or_size[a]
    while parent >= 0:
        if self.parent_or_size[parent] < 0:
            return parent
        self.parent_or_size[a], a, parent = (
            self.parent_or_size[parent],
            self.parent_or_size[parent],
            self.parent_or_size[self.parent_or_size[parent]]
        )

    return a
```