### PR TITLE
Add `pow_mod` as a wrapper of `pow`

### DIFF
--- a/atcoder/math.py
+++ b/atcoder/math.py
@@ -2,6 +2,9 @@ import typing
 
 import atcoder._math
 
+def pow_mod(x: int, n: int, m: int) -> int:
+    return pow(x, n, m)
+
 
 def inv_mod(x: int, m: int) -> int:
     assert 1 <= m

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -8,7 +8,4 @@ Math
    atcoder.math.inv_mod
    atcoder.math.crt
    atcoder.math.floor_sum
-
-Note
-----
-``atcoder.math.pow_mod`` is not implemented. Use ``pow(x, n, m)`` instead of it.
+   atcoder.math.pow_mod


### PR DESCRIPTION
#67 
I implement the `atcoder.math.pow_mod` as a wrapper of `pow` without introducing additional assertions.
Do we need to modify `docs/math.rst` either?